### PR TITLE
Couple of minor fixes as listed below:

### DIFF
--- a/src/include/qnio.h
+++ b/src/include/qnio.h
@@ -154,11 +154,7 @@ struct conn
 /*
  * "struct conn" flags.
  */
-#define CONN_FLAG_REGULAR           0x0001
-#define CONN_FLAG_STREAM            0x0002
-#define CONN_FLAG_STREAM_CLOSE      0x0004
-#define CONN_FLAG_DISCONNECTED      0x0008
-#define CONN_FLAG_INPROGRESS        0x0010
+#define CONN_FLAG_DISCONNECTED      0x0001
 
 void process_outgoing_messages(struct conn *conn);
 void process_incoming_messages(struct conn *conn);

--- a/src/include/qnio_client.h
+++ b/src/include/qnio_client.h
@@ -1,14 +1,8 @@
 #ifndef QNIO_CLIENT_HEADER_DEFINED
 #define QNIO_CLIENT_HEADER_DEFINED
 
-/*
- * First 8 will be used for default connections.
- * Last one is used specific connections such as EDS.
- */
-#define MAX_CLIENT_EPOLL_UNITS      9
-#define CHNL_DEFAULT_CONNECTIONS    8
-#define MAX_STREAMS                 1024
-#define MAX_CONN                    (MAX_STREAMS + CHNL_DEFAULT_CONNECTIONS)
+#define MAX_CLIENT_EPOLL_UNITS      8
+#define MAX_CONN                    8
 
 struct network_channel_arg {
     char host[NAME_SZ64];
@@ -48,7 +42,6 @@ struct network_channel
     uint64_t free_conn_idx;
     int refcount;
     int flags;
-    int next_stream_idx;
     pthread_mutex_t conn_lock;
 };
 


### PR DESCRIPTION
        1) Avoid network connect operations in I/O context.
        2) Remove "Stream" connections, as they are not required for
           QEMU.
        3) Make device host information file(targets list) optional.