### PR TITLE
Implementation of SSL in libqnio

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -23,15 +23,21 @@ BASE_OBJECTS = $(BASE_SOURCES:.c=.o)
 -include $(BASE_SOURCES:.c=.d)
 
 TEST_TARGET = qnio_server 
-TEST_SOURCES = $(shell echo test/*.c)
-TEST_OBJS = $(shell echo test/*.o lib/qnio/*.d)
+TEST_SOURCES = $(shell echo test/server.c)
+TEST_OBJS = $(shell echo test/server.o lib/qnio/server.d)
 TEST_OBJECTS = $(TEST_SOURCES:.c=.o)
 -include $(TEST_SOURCES:.c=.d)
+
+TEST_CLIENT_TARGET = qnio_client
+TEST_CLIENT_SOURCES = $(shell echo test/client.c)
+TEST_CLIENT_OBJS = $(shell echo test/client.o lib/qnio/client.d)
+TEST_CLIENT_OBJECTS = $(TEST_CLIENT_SOURCES:.c=.o)
+-include $(TEST_CLIENT_SOURCES:.c=.d)
 
 debug:
 	$(MAKE) -f $(MAKEFILE) DEV2="-DDEBUG_QNIO";
 
-all: $(BASE_TARGET) $(TEST_TARGET)
+all: $(BASE_TARGET) $(TEST_TARGET) $(TEST_CLIENT_TARGET)
 
 .c.o:
 	$(CC) $(CFLAGS) $(CPPFLAGS) $(DEV2) $(DEPFLAGS) $(OPTFLAGS) -c -o $@ $<
@@ -40,21 +46,28 @@ $(BASE_TARGET): $(BASE_OBJECTS)
 	$(CC) $(FLAGS) $(CFLAGS) $(LDFLAGS) -o $(BASE_TARGET) $(BASE_OBJECTS)
 
 $(TEST_TARGET): $(TEST_OBJECTS) $(BASE_TARGET)
-	$(CC) $(FLAGS) $(CFLAGS) -o $(TEST_TARGET) $(TEST_OBJECTS) -L. -lqnio
+	$(CC) $(FLAGS) $(CFLAGS) -o $(TEST_TARGET) $(TEST_OBJECTS) -L. -lqnio -lssl -lcrypto
+
+$(TEST_CLIENT_TARGET): $(TEST_CLIENT_OBJECTS) $(BASE_TARGET)
+	$(CC) $(FLAGS) $(CFLAGS) -o $(TEST_CLIENT_TARGET) $(TEST_CLIENT_OBJECTS) -L. -lqnio -lssl -lcrypto -lrt
 
 clean:
 	\rm -f $(BASE_TARGET)
 	\rm -f $(BASE_OBJS)
 	\rm -f $(TEST_TARGET)
 	\rm -f $(TEST_OBJS)
+	\rm -f $(TEST_CLIENT_TARGET)
+	\rm -f $(TEST_CLIENT_OBJS)
 
 install: all
 	mkdir -p $(HEADERS) || exit
 	cp -f include/qnio_api.h $(HEADERS)/qnio_api.h
 	cp -f $(BASE_TARGET) $(LIBRARY)/$(BASE_TARGET)
 	cp -f $(TEST_TARGET) ${TEST_TARGET_DIR}/$(TEST_TARGET)
+	cp -f $(TEST_CLIENT_TARGET) ${TEST_TARGET_DIR}/$(TEST_CLIENT_TARGET)
 
 uninstall:
 	rm -f $(HEADERS)/qnio_api.h
 	rm -f $(LIBRARY)/$(BASE_TARGET)
 	rm -f ${TEST_TARGET_DIR}/$(TEST_TARGET)
+	rm -f ${TEST_TARGET_DIR}/$(TEST_CLIENT_TARGET)

--- a/src/Makefile
+++ b/src/Makefile
@@ -16,7 +16,7 @@ LIBRARY      = /usr/lib64
 
 OPTFLAGS     = $(DEBUGFLAGS)
 
-BASE_TARGET = libqnio.so
+BASE_TARGET = libvxhs.so
 BASE_SOURCES = $(shell echo lib/qnio/*.c) 
 BASE_OBJS = $(shell echo lib/qnio/*.o lib/qnio/*.d)
 BASE_OBJECTS = $(BASE_SOURCES:.c=.o)

--- a/src/Makefile
+++ b/src/Makefile
@@ -46,10 +46,10 @@ $(BASE_TARGET): $(BASE_OBJECTS)
 	$(CC) $(FLAGS) $(CFLAGS) $(LDFLAGS) -o $(BASE_TARGET) $(BASE_OBJECTS)
 
 $(TEST_TARGET): $(TEST_OBJECTS) $(BASE_TARGET)
-	$(CC) $(FLAGS) $(CFLAGS) -o $(TEST_TARGET) $(TEST_OBJECTS) -L. -lqnio -lssl -lcrypto
+	$(CC) $(FLAGS) $(CFLAGS) -o $(TEST_TARGET) $(TEST_OBJECTS) -L. -lvxhs -lssl -lcrypto
 
 $(TEST_CLIENT_TARGET): $(TEST_CLIENT_OBJECTS) $(BASE_TARGET)
-	$(CC) $(FLAGS) $(CFLAGS) -o $(TEST_CLIENT_TARGET) $(TEST_CLIENT_OBJECTS) -L. -lqnio -lssl -lcrypto -lrt
+	$(CC) $(FLAGS) $(CFLAGS) -o $(TEST_CLIENT_TARGET) $(TEST_CLIENT_OBJECTS) -L. -lvxhs -lssl -lcrypto -lrt
 
 clean:
 	\rm -f $(BASE_TARGET)

--- a/src/include/defs.h
+++ b/src/include/defs.h
@@ -30,6 +30,8 @@
 #include <signal.h>
 #include <errno.h>
 #include <sys/eventfd.h>
+#include <openssl/ssl.h>
+#include <openssl/err.h>
 
 #include "types.h"
 #include "datastruct.h"

--- a/src/include/iio.h
+++ b/src/include/iio.h
@@ -11,6 +11,7 @@
 #define QNIO_ERR_SUCCESS               0
 #define QNIO_ERR_CHAN_EXISTS           1
 #define QNIO_ERR_CHAN_CREATE_FAILED    2
+#define QNIO_ERR_AUTHZ_FAILED          3
 
 #define MSG_POOL_SIZE               4096 
 
@@ -70,6 +71,7 @@ struct qnio_header
     uint64_t io_remote_hdl;
     uint32_t io_remote_flags;
     char target[NAME_SZ64];
+    char instance[NAME_SZ64];
 };
 
 struct qnio_msg

--- a/src/include/iio.h
+++ b/src/include/iio.h
@@ -71,7 +71,6 @@ struct qnio_header
     uint64_t io_remote_hdl;
     uint32_t io_remote_flags;
     char target[NAME_SZ64];
-    char instance[NAME_SZ64];
 };
 
 struct qnio_msg

--- a/src/include/qnio.h
+++ b/src/include/qnio.h
@@ -28,10 +28,10 @@
 #define IO_POOL_BUF_SIZE            65536 
 #define BUF_ALIGN                   4096
 #define CRC_MODULO                  256
-#define SECURE_IMPL                 "/var/lib/libqnio/secure"
-#define SERVER_KEY                  "/var/lib/libqnio/server.key"
-#define SERVER_CERT                 "/var/lib/libqnio/server.cert"
-#define CLIENT_KEYSTORE             "/var/lib/libqnio/"
+#define SECURE_IMPL                 "/var/lib/libvxhs/secure"
+#define SERVER_KEY                  "/var/lib/libvxhs/server.key"
+#define SERVER_CERT                 "/var/lib/libvxhs/server.cert"
+#define CLIENT_KEYSTORE             "/var/lib/libvxhs/"
 
 #define QNIO_SYSCALL(expression)                   \
     ({ long int __result;                         \

--- a/src/include/qnio.h
+++ b/src/include/qnio.h
@@ -28,6 +28,10 @@
 #define IO_POOL_BUF_SIZE            65536 
 #define BUF_ALIGN                   4096
 #define CRC_MODULO                  256
+#define SECURE_IMPL                 "/var/lib/libqnio/secure"
+#define SERVER_KEY                  "/var/lib/libqnio/server.key"
+#define SERVER_CERT                 "/var/lib/libqnio/server.cert"
+#define CLIENT_KEYSTORE             "/var/lib/libqnio/"
 
 #define QNIO_SYSCALL(expression)                   \
     ({ long int __result;                         \
@@ -44,6 +48,7 @@ struct qnio_common_ctx {
     enum qnio_mode mode;
     uint64_t in, out; /* IN/OUT traffic counters */
     qnio_notify notify;
+    SSL_CTX *ssl_ctx;
 };
 
 enum NSReadState { /* Network stream read state */
@@ -93,6 +98,7 @@ struct io_class
 
 extern const struct io_class io_socket;
 extern const struct io_class io_event;
+extern const struct io_class io_ssl;
 
 /*
  * Data exchange endpoint. Represents one end of a connection
@@ -103,6 +109,7 @@ struct endpoint
     unsigned int flags;
     struct conn *conn;
     const struct io_class *io_class; /* IO class */
+    SSL *ssl;   /* For secure communiation */
 };
 
 /*

--- a/src/include/qnio_api.h
+++ b/src/include/qnio_api.h
@@ -62,7 +62,7 @@ typedef void (*iio_cb_t) (void *ctx, uint32_t opcode, uint32_t error);
  *     Intilize the library state. This should be called at the
  *     begining before issuing any library call.
  */
-int iio_init(int32_t version, iio_cb_t cb, char *instance);
+int iio_init(int32_t version, iio_cb_t cb, const char *instance);
 
 /*
  * DESCRIPTION:

--- a/src/include/qnio_api.h
+++ b/src/include/qnio_api.h
@@ -62,7 +62,7 @@ typedef void (*iio_cb_t) (void *ctx, uint32_t opcode, uint32_t error);
  *     Intilize the library state. This should be called at the
  *     begining before issuing any library call.
  */
-int iio_init(int32_t version, iio_cb_t cb);
+int iio_init(int32_t version, iio_cb_t cb, char *instance);
 
 /*
  * DESCRIPTION:

--- a/src/include/qnio_client.h
+++ b/src/include/qnio_client.h
@@ -1,6 +1,8 @@
 #ifndef QNIO_CLIENT_HEADER_DEFINED
 #define QNIO_CLIENT_HEADER_DEFINED
 
+#include <openssl/ssl.h>
+
 #define MAX_CLIENT_EPOLL_UNITS      8
 #define MAX_CONN                    8
 
@@ -23,6 +25,7 @@ struct qnio_client_ctx {
     pthread_mutex_t chnl_lock;
     qnio_map *channels;
     struct qnio_client_epoll_unit ceu[MAX_CLIENT_EPOLL_UNITS];
+    char *instance;
 };
 
 /*
@@ -46,5 +49,7 @@ struct network_channel
 };
 
 struct channel_driver* qnc_driver_init(qnio_notify client_notify);
+struct channel_driver* qnc_secure_driver_init(qnio_notify client_notify, char *instance);
+extern struct qnio_client_ctx *qnc_ctx;
 
 #endif /* QNIO_CLIENT_HEADER_DEFINED */

--- a/src/include/qnio_client.h
+++ b/src/include/qnio_client.h
@@ -25,7 +25,7 @@ struct qnio_client_ctx {
     pthread_mutex_t chnl_lock;
     qnio_map *channels;
     struct qnio_client_epoll_unit ceu[MAX_CLIENT_EPOLL_UNITS];
-    char *instance;
+    const char *instance;
 };
 
 /*
@@ -49,7 +49,7 @@ struct network_channel
 };
 
 struct channel_driver* qnc_driver_init(qnio_notify client_notify);
-struct channel_driver* qnc_secure_driver_init(qnio_notify client_notify, char *instance);
+struct channel_driver* qnc_secure_driver_init(qnio_notify client_notify, const char *instance);
 extern struct qnio_client_ctx *qnc_ctx;
 
 #endif /* QNIO_CLIENT_HEADER_DEFINED */

--- a/src/include/qnio_server.h
+++ b/src/include/qnio_server.h
@@ -1,6 +1,8 @@
 #ifndef QNIO_SERVER_HEADER_DEFINED
 #define QNIO_SERVER_HEADER_DEFINED
 
+#include <openssl/ssl.h>
+
 #define MAX_EPOLL_UNITS             16 
 #define QNIO_DEFAULT_PORT           "9999"
 

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -16,5 +16,8 @@ int make_socket_non_blocking(int sfd);
 char *safe_strncpy(char *dest, const char *src, size_t n);
 int compare_key(const void *x, const void *y);
 int compare_int(const void *x, const void *y);
+SSL_CTX *init_server_ssl_ctx(); 
+SSL_CTX *init_client_ssl_ctx(char *instanceid); 
+int is_secure(); 
 
 #endif /* UTILS_HEADER_DEFINED */

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -16,8 +16,8 @@ int make_socket_non_blocking(int sfd);
 char *safe_strncpy(char *dest, const char *src, size_t n);
 int compare_key(const void *x, const void *y);
 int compare_int(const void *x, const void *y);
-SSL_CTX *init_server_ssl_ctx(); 
-SSL_CTX *init_client_ssl_ctx(char *instanceid); 
+SSL_CTX *init_server_ssl_ctx(void); 
+SSL_CTX *init_client_ssl_ctx(const char *instanceid); 
 int is_secure(); 
 
 #endif /* UTILS_HEADER_DEFINED */

--- a/src/lib/qnio/iioapi.c
+++ b/src/lib/qnio/iioapi.c
@@ -396,7 +396,7 @@ client_callback(struct qnio_msg *msg)
 }
 
 int
-iio_init(int32_t version, iio_cb_t cb, char *instance)
+iio_init(int32_t version, iio_cb_t cb, const char *instance)
 {
     if (version <  qnio_min_version || version > qnio_max_version) {
         nioDbg("Version [%d] not supported. Supported versions[%d - %d]",

--- a/src/lib/qnio/iioapi.c
+++ b/src/lib/qnio/iioapi.c
@@ -67,7 +67,7 @@ iio_read_hostinfo(const char *devid)
             continue;
         }
         nioDbg("iio_read_hostinfo: %s\n", str);
-        strncpy(hostinfo->hosts[hostinfo->nhosts], str, NAME_SZ);
+        safe_strncpy(hostinfo->hosts[hostinfo->nhosts], str, NAME_SZ);
         hostinfo->nhosts ++;
     }
     fclose(fp);
@@ -492,7 +492,7 @@ iio_open(const char *uri, const char *devid, uint32_t flags)
     if (hostinfo == NULL) {
         nioDbg("Unable to read the host information for device %s\n", devid);
         hostinfo = (struct iio_vdisk_hostinfo *)malloc(sizeof (struct iio_vdisk_hostinfo));
-        strncpy(hostinfo->hosts[0], uri, NAME_SZ);
+        safe_strncpy(hostinfo->hosts[0], uri, NAME_SZ);
         hostinfo->nhosts = 1;
         hostinfo->failover_idx = 0;
     }

--- a/src/lib/qnio/iioapi.c
+++ b/src/lib/qnio/iioapi.c
@@ -17,7 +17,7 @@
 #include "cJSON.h"
 #include <inttypes.h>
 
-#define VDISK_TARGET_DIR            "/var/lib/libqnio/vdisk"
+#define VDISK_TARGET_DIR            "/var/lib/libvxhs/vdisk"
 #define QNIO_QEMU_VDISK_SIZE_STR    "vdisk_size_bytes"
 #define IP_ADDR_LEN                 20
 #define SEND_RECV_SLEEP             200 /* micro seconds */
@@ -558,7 +558,6 @@ iio_readv(void *dev_handle, void *ctx_out, struct iovec *iov, int iovcnt,
     msg->hinfo.io_flags |= IOR_SOURCE_TAG_APPIO;
     msg->hinfo.flags = QNIO_FLAG_REQ_NEED_RESP;
     safe_strncpy(msg->hinfo.target, device->devid, NAME_SZ64);
-    safe_strncpy(msg->hinfo.instance, qnc_ctx->instance, NAME_SZ64);
     msg->user_ctx = ctx_out;
     msg->send = NULL;
     msg->recv = new_io_vector(1, NULL);
@@ -599,7 +598,6 @@ iio_writev(void *dev_handle, void *ctx_out, struct iovec *iov, int iovcnt,
     msg->hinfo.io_flags |= IOR_SOURCE_TAG_APPIO;
     msg->hinfo.flags = QNIO_FLAG_REQ_NEED_ACK;
     safe_strncpy(msg->hinfo.target, device->devid, NAME_SZ64);
-    safe_strncpy(msg->hinfo.instance, qnc_ctx->instance, NAME_SZ64);
     msg->user_ctx = ctx_out;
     msg->recv = NULL;
     msg->send = new_io_vector(1, NULL);
@@ -691,7 +689,6 @@ iio_ioctl_json(void *dev_handle, uint32_t opcode, char *injson,
     msg->recv = NULL;
     msg->hinfo.payload_size = data.iov_len;
     safe_strncpy(msg->hinfo.target, device->devid, NAME_SZ64);
-    safe_strncpy(msg->hinfo.instance, qnc_ctx->instance, NAME_SZ64);
     msg->user_ctx = ctx_out;
     msg->hinfo.flags = QNIO_FLAG_REQ_NEED_RESP;
     err = iio_msg_submit(device, msg, flags);
@@ -773,7 +770,6 @@ iio_check_failover_ready(struct iio_device *device)
     msg->hinfo.payload_size = 0;
     msg->recv = NULL;
     safe_strncpy(msg->hinfo.target, device->devid, NAME_SZ64);
-    safe_strncpy(msg->hinfo.instance, qnc_ctx->instance, NAME_SZ64);
     msg->user_ctx = NULL;
     msg->hinfo.flags = QNIO_FLAG_REQ_NEED_RESP | QNIO_FLAG_SYNC_REQ;
     msg->reserved = device;

--- a/src/lib/qnio/io_ssl.c
+++ b/src/lib/qnio/io_ssl.c
@@ -1,0 +1,58 @@
+/*
+ * Network IO library for VxHS QEMU block driver (Veritas Technologies)
+ *
+ * This work is licensed under the terms of the GNU GPL, version 2.  See
+ * the COPYING file in the top-level directory.
+ *
+ * Contributions after 2014-08-15 are licensed under the terms of the
+ * GNU GPL, version 2 or (at your option) any later version.
+ */
+
+#include "defs.h"
+#include "qnio.h"
+
+static int
+read_ssl(struct endpoint *endpoint, void *buf, size_t len)
+{
+    assert(endpoint->ssl != NULL);
+    return (SSL_read(endpoint->ssl, buf, len));
+}
+
+static int
+write_ssl(struct endpoint *endpoint, const void *buf, size_t len)
+{
+    assert(endpoint->ssl != NULL);
+    return (SSL_write(endpoint->ssl, buf, len));
+}
+
+static int
+readv_ssl(struct endpoint *endpoint, struct iovec *vec, int count) 
+{
+    assert(endpoint->ssl != NULL);
+    return (SSL_read(endpoint->ssl, vec[0].iov_base, vec[0].iov_len));
+}
+
+static int
+writev_ssl(struct endpoint *endpoint, struct iovec *vec, int count)
+{
+    assert(endpoint->ssl != NULL);
+    return (SSL_write(endpoint->ssl, vec[0].iov_base, vec[0].iov_len));
+}
+
+
+static void
+close_ssl(struct endpoint *endpoint)
+{
+    assert(endpoint->sock != -1);
+    SSL_free(endpoint->ssl);
+    close(endpoint->sock);
+}
+
+const struct io_class io_ssl = {
+    "ssl",
+    read_ssl,
+    write_ssl,
+    close_ssl,
+    readv_ssl,
+    writev_ssl
+};

--- a/src/lib/qnio/nio_client.c
+++ b/src/lib/qnio/nio_client.c
@@ -719,7 +719,7 @@ qnc_driver_init(qnio_notify client_notify)
 }
 
 struct channel_driver *
-qnc_secure_driver_init(qnio_notify client_notify, char *instance)
+qnc_secure_driver_init(qnio_notify client_notify, const char *instance)
 {
     struct channel_driver *drv = NULL;
 
@@ -732,7 +732,7 @@ qnc_secure_driver_init(qnio_notify client_notify, char *instance)
     }
 
     nioDbg("Client is running in secure mode");
-    qnc_ctx->instance = instance;
+    qnc_ctx->instance = (const char *) instance;
     cmn_ctx->ssl_ctx = init_client_ssl_ctx(instance);
     return drv;
 }

--- a/src/lib/qnio/nio_client.c
+++ b/src/lib/qnio/nio_client.c
@@ -43,7 +43,7 @@ open_connection(struct network_channel *netch, int flags, int euid)
     struct conn *c = NULL;
     int err;
     struct addrinfo hints, *infos = NULL;
-    SSL *ssl;
+    SSL *ssl = NULL;
 
     /* creating the client socket */
     if ((sock = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
@@ -89,6 +89,7 @@ open_connection(struct network_channel *netch, int flags, int euid)
         SSL_set_fd(ssl, sock);
         if (SSL_connect(ssl) == -1) {
             nioDbg("ssl connect failed");
+            SSL_free(ssl);
             return (NULL);
         }
     }
@@ -163,6 +164,9 @@ out:
     }
     if(c) {
         free(c);
+    }
+    if(ssl) {
+        SSL_free(ssl);
     }
     return NULL;
 }

--- a/src/lib/qnio/nio_server.c
+++ b/src/lib/qnio/nio_server.c
@@ -452,7 +452,7 @@ qns_server_start(char *node, char *port)
                             {
                                 nioDbg("SSL_error is want read or want write %d", ret);
                                 /* put fd in epoll loop to try again */
-                                event.events = EPOLLIN;
+                                event.events = EPOLLIN | EPOLLOUT;
                                 ep = (struct endpoint *) malloc(sizeof(struct endpoint));
                                 ep->sock = infd;
                                 ep->ssl = ssl;

--- a/src/lib/qnio/nio_server.c
+++ b/src/lib/qnio/nio_server.c
@@ -340,6 +340,7 @@ qns_server_start(char *node, char *port)
 {
     qnio_error_t            err = QNIOERROR_SUCCESS;
     struct epoll_event      event;
+    struct endpoint         *ep;
     struct qnio_epoll_unit  *eu = NULL;
     int                     sfd, s, n, i;
     int                     eu_counter = 0;
@@ -430,16 +431,6 @@ qns_server_start(char *node, char *port)
                         nioDbg("Accepted connection on descriptor %d "
                                   "(host=%s, port=%s)\n", infd, hbuf, sbuf);
                     }
-                    if(cmn_ctx->ssl_ctx)
-                    {
-                        ssl = SSL_new(cmn_ctx->ssl_ctx);
-                        SSL_set_fd(ssl, infd);
-                        ret = SSL_accept(ssl);
-                        if (ret <= 0) {
-                            nioDbg("ssl accept failed %d", SSL_get_error(ssl, ret));
-                            return -1;
-                        }
-                    }
 
                     /* Make the incoming socket non-blocking and add it to the
                      *  list of fds to monitor. */
@@ -447,6 +438,42 @@ qns_server_start(char *node, char *port)
                     if (s == -1) {
                         return (-1);
                     }
+
+                    if(cmn_ctx->ssl_ctx)
+                    {
+                        ssl = SSL_new(cmn_ctx->ssl_ctx);
+                        SSL_set_fd(ssl, infd);
+                        ret = SSL_accept(ssl);
+                        if (ret <= 0) {
+                            /* Maybe try SSL_accept again */
+                            nioDbg("SSL_accept failed. Will retry");
+                            ret = SSL_get_error(ssl, ret);
+                            if (ret == SSL_ERROR_WANT_READ || ret == SSL_ERROR_WANT_WRITE) 
+                            {
+                                nioDbg("SSL_error is want read or want write %d", ret);
+                                /* put fd in epoll loop to try again */
+                                event.events = EPOLLIN;
+                                ep = (struct endpoint *) malloc(sizeof(struct endpoint));
+                                ep->sock = infd;
+                                ep->ssl = ssl;
+                                event.data.ptr = ep;
+                                s = epoll_ctl(qns_ctx->epoll_fd, EPOLL_CTL_ADD, infd, &event);
+                                if (s == -1) {
+                                    nioDbg("epoll_ctl error");
+                                    return (-1);
+                                }
+                                continue;
+                            }
+                            else
+                            {
+                                nioDbg("ssl accept failed %d", SSL_get_error(ssl, ret));
+                            
+                                SSL_free(ssl);
+                                return -1;
+                            }
+                        }
+                    }
+
                     eu = &qns_ctx->eu[eu_counter];
                     eu_counter++;
                     if(eu_counter == MAX_EPOLL_UNITS)
@@ -469,6 +496,64 @@ qns_server_start(char *node, char *port)
                     }
                 }
                 continue;
+            }
+            else if (qns_ctx->activefds[i].events & EPOLLIN)
+            {
+                int             infd;
+                int             sslerr;
+                if(!cmn_ctx->ssl_ctx)
+                {
+                    /* why did we get here? */
+                    nioDbg("Unknown error");
+                    return (-1);
+                }
+                /* complete ssl accept */
+                nioDbg("Completing ssl accept");
+                ep = (struct endpoint *)qns_ctx->activefds[i].data.ptr;
+                infd = ep->sock;
+                ssl = ep->ssl;
+                epoll_ctl(qns_ctx->epoll_fd, EPOLL_CTL_DEL,
+                          infd, &event);
+                ret = SSL_accept(ssl);
+                if (ret <= 0) {
+                    nioDbg("ssl accept failed %d", ret);
+                    /* Maybe try SSL_accept again */
+                    sslerr = SSL_get_error(ssl, ret);
+                    nioDbg("ssl error is %d", sslerr);
+                    if (sslerr == SSL_ERROR_WANT_READ || sslerr == SSL_ERROR_WANT_WRITE) 
+                    {
+                        nioDbg("ssl accept still not complete");
+                        continue;
+                    }
+                    else
+                    {
+                        nioDbg("ssl accept failed %s", ERR_error_string(ERR_get_error(), NULL));
+                        SSL_free(ssl);
+                        if (ep) free(ep);
+                        return -1;
+                    }
+                }
+
+                if (ep) free(ep);
+                eu = &qns_ctx->eu[eu_counter];
+                eu_counter++;
+                if(eu_counter == MAX_EPOLL_UNITS)
+                    eu_counter = 0;
+                event.data.fd = infd;
+                nioDbg("Adding connection to epoll unit #%d",eu_counter);
+                event.events = EPOLLIN | EPOLLRDHUP;
+                event.data.ptr = add_socket(infd, eu, ssl);
+                if(event.data.ptr == NULL) {
+                    nioDbg("qns_server_start: add_socket returned NULL");
+                    break;
+                }
+
+                s = epoll_ctl(eu->recv_epoll_fd,
+                    EPOLL_CTL_ADD, infd, &event);
+                if (s == -1) {
+                    nioDbg("qns_server_start: epoll_ctl error %d",errno);
+                    return (-1);
+                }
             }
         }
     }

--- a/src/lib/qnio/nio_server.c
+++ b/src/lib/qnio/nio_server.c
@@ -452,7 +452,10 @@ qns_server_start(char *node, char *port)
                             {
                                 nioDbg("SSL_error is want read or want write %d", ret);
                                 /* put fd in epoll loop to try again */
-                                event.events = EPOLLIN | EPOLLOUT;
+                                if (ret == SSL_ERROR_WANT_READ)
+                                    event.events = EPOLLIN;
+                                else
+                                    event.events = EPOLLOUT;
                                 ep = (struct endpoint *) malloc(sizeof(struct endpoint));
                                 ep->sock = infd;
                                 ep->ssl = ssl;
@@ -522,6 +525,10 @@ qns_server_start(char *node, char *port)
                     nioDbg("ssl error is %d", sslerr);
                     if (sslerr == SSL_ERROR_WANT_READ || sslerr == SSL_ERROR_WANT_WRITE) 
                     {
+                        if (sslerr == SSL_ERROR_WANT_READ)
+                            qns_ctx->activefds[i].events = EPOLLIN;
+                        else
+                            qns_ctx->activefds[i].events = EPOLLOUT;
                         nioDbg("ssl accept still not complete");
                         continue;
                     }

--- a/src/lib/qnio/utils.c
+++ b/src/lib/qnio/utils.c
@@ -56,19 +56,21 @@ init_server_ssl_ctx()
     if (SSL_CTX_use_certificate_file(ctx, SERVER_CERT, SSL_FILETYPE_PEM) < 0) 
     {
         nioDbg("Unable to use server certificate");
+        SSL_CTX_free(ctx);
         return NULL;
     }
 
     if (SSL_CTX_use_PrivateKey_file(ctx, SERVER_KEY, SSL_FILETYPE_PEM) < 0 ) 
     {
         nioDbg("Unable to use server key file");
+        SSL_CTX_free(ctx);
         return NULL;
     }
     return ctx;
 }
 
 SSL_CTX *
-init_client_ssl_ctx(char *instanceid)
+init_client_ssl_ctx(const char *instanceid)
 {
     const SSL_METHOD *method;
     char clientkey[512] = { 0 };
@@ -110,12 +112,14 @@ init_client_ssl_ctx(char *instanceid)
     if (SSL_CTX_use_certificate_file(ctx, clientcert, SSL_FILETYPE_PEM) < 0) 
     {
         nioDbg("Unable to use client certificate");
+        SSL_CTX_free(ctx);
         return NULL;
     }
 
     if (SSL_CTX_use_PrivateKey_file(ctx, clientkey, SSL_FILETYPE_PEM) < 0 ) 
     {
         nioDbg("Unable to use server key file");
+        SSL_CTX_free(ctx);
         return NULL;
     }
     return ctx;

--- a/src/lib/qnio/utils.c
+++ b/src/lib/qnio/utils.c
@@ -83,7 +83,7 @@ init_client_ssl_ctx(const char *instanceid)
 
     if (access(clientkey, F_OK) != 0)
     {
-        nioDbg("Client key not found");
+        nioDbg("Client key not found %s", clientkey);
         return NULL;
     }
 

--- a/src/lib/qnio/utils.c
+++ b/src/lib/qnio/utils.c
@@ -9,6 +9,117 @@
  */
 
 #include "defs.h"
+#include "qnio.h"
+
+int 
+is_secure()
+{
+    if (access(SECURE_IMPL, F_OK) != 0)
+    {
+        nioDbg("Secure implementation not enabled\n");
+        return 0;
+    }
+    return 1;
+}
+
+SSL_CTX *
+init_server_ssl_ctx()
+{
+    const SSL_METHOD *method;
+    SSL_CTX *ctx = NULL;
+
+    nioDbg("initializing server ssl ctx %s\n", SERVER_KEY);
+    if (access(SERVER_KEY, F_OK) != 0)
+    {
+        nioDbg("Server key not found");
+        return NULL;
+    }
+
+    if (access(SERVER_CERT, F_OK) != 0)
+    {
+        nioDbg("Server cert not found");
+        return NULL;
+    }
+
+    SSL_load_error_strings();   
+    OpenSSL_add_ssl_algorithms();
+    method = SSLv23_server_method();
+
+    ctx = SSL_CTX_new(method);
+    if (!ctx) 
+    {
+        nioDbg("Unable to create SSL context");
+        return NULL;
+    }
+
+    /* Set the key and cert */
+    if (SSL_CTX_use_certificate_file(ctx, SERVER_CERT, SSL_FILETYPE_PEM) < 0) 
+    {
+        nioDbg("Unable to use server certificate");
+        return NULL;
+    }
+
+    if (SSL_CTX_use_PrivateKey_file(ctx, SERVER_KEY, SSL_FILETYPE_PEM) < 0 ) 
+    {
+        nioDbg("Unable to use server key file");
+        return NULL;
+    }
+    return ctx;
+}
+
+SSL_CTX *
+init_client_ssl_ctx(char *instanceid)
+{
+    const SSL_METHOD *method;
+    char clientkey[512] = { 0 };
+    char clientcert[512] = { 0 };
+    SSL_CTX *ctx = NULL;
+
+    strcpy(clientkey, CLIENT_KEYSTORE);
+    strncat(clientkey, instanceid, 64);
+    strncat(clientkey, ".key", 4);
+
+    if (access(clientkey, F_OK) != 0)
+    {
+        nioDbg("Client key not found");
+        return NULL;
+    }
+
+    strcpy(clientcert, CLIENT_KEYSTORE);
+    strncat(clientcert, instanceid, 64);
+    strncat(clientcert, ".cert", 5);
+
+    if (access(clientcert, F_OK) != 0)
+    {
+        nioDbg("Client cert not found");
+        return NULL;
+    }
+
+    SSL_load_error_strings();   
+    OpenSSL_add_ssl_algorithms();
+    method = SSLv23_client_method();
+
+    ctx = SSL_CTX_new(method);
+    if (!ctx) 
+    {
+        nioDbg("Unable to create client SSL context");
+        return NULL;
+    }
+
+    /* Set the key and cert */
+    if (SSL_CTX_use_certificate_file(ctx, clientcert, SSL_FILETYPE_PEM) < 0) 
+    {
+        nioDbg("Unable to use client certificate");
+        return NULL;
+    }
+
+    if (SSL_CTX_use_PrivateKey_file(ctx, clientkey, SSL_FILETYPE_PEM) < 0 ) 
+    {
+        nioDbg("Unable to use server key file");
+        return NULL;
+    }
+    return ctx;
+}
 
 void
 set_close_on_exec(int fd)

--- a/src/test/client.c
+++ b/src/test/client.c
@@ -1,0 +1,159 @@
+/*
+ * Network IO library for VxHS QEMU block driver (Veritas Technologies)
+ *
+ * This work is licensed under the terms of the GNU GPL, version 2.  See
+ * the COPYING file in the top-level directory.
+ *
+ * Contributions after 2014-08-15 are licensed under the terms of the
+ * GNU GPL, version 2 or (at your option) any later version.
+ */
+
+#include <pthread.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <sys/uio.h>
+#include "defs.h"
+#include "qnio.h"
+#include "qnio_client.h"
+
+#define BILLION                     1E9
+
+/* global variables */
+int iops = 10;
+int iosize = 8192;
+int verbose = 0;
+char *hostname = "127.0.0.1";
+char *target = "testdevice";
+struct timespec start;
+void *ctx = NULL;
+void *handle;
+char *instance = "testinstance";
+int reply = 0;
+struct timespec start;
+struct timespec estart;
+double t,l;
+
+void
+start_timer(struct timespec *t)
+{
+    clock_gettime(CLOCK_MONOTONIC, t);
+}
+
+double
+stop_timer(struct timespec *t)
+{
+    struct timespec now;
+    double diff;
+
+    clock_gettime(CLOCK_MONOTONIC, &now);
+    diff = (double) ( now.tv_sec - t->tv_sec )
+         + ( now.tv_nsec - t->tv_nsec )
+            / BILLION;
+
+    return diff;
+}
+
+void 
+iio_cb(void *ctx,  uint32_t opcode,  uint32_t error)
+{
+    ck_pr_inc_int(&reply);
+    if (error != 0)
+    {
+        printf("Error in response %d\n", error);
+    }
+    if (reply == iops)
+    {
+        t = stop_timer(&start);
+        printf("Total time: %f\n", t);
+        printf("Submission time: %f\n", l);
+        printf("IOPS: %f\n", iops/t);
+        exit(0);
+    }    
+    return;
+}
+
+void
+usage()
+{
+    printf("Usage: qnio_client [-t <target host>] [-b <block size>] [-c <count>] [-d device] [-v] [-h] \n"
+            "\t t -> Target (default: localhost)\n"
+            "\t b -> Block size in bytes (default: 8192)\n"
+            "\t c -> Number of IOs (default: 10)\n"
+            "\t d -> Device (default: testdevice)\n"
+            "\t h -> Help\n");
+}
+
+int main(int argc, char **argv)
+{
+    struct iovec data;
+    char *buf = NULL;
+    int c,i=1;
+    int ret;
+
+    while((c = getopt(argc, argv, "b:t:c:d:vhr")) != -1)
+    {
+        switch(c)
+        {
+            case 't':
+                hostname = optarg;
+                break;
+            case 'c':
+                iops = atoi(optarg);
+                break;
+            case 'b':
+                iosize = atoi(optarg);
+                break;
+            case 'd':
+                target = optarg;
+                break;
+            case 'v':
+                verbose = 1;
+                break;
+            case 'h':
+            default:
+                usage();
+                exit(0);
+        }
+    }
+
+    ret = iio_init(34, iio_cb, instance);
+    if (ret != 0)
+    {
+        printf("Client init failed\n");
+        exit(1);
+    }
+
+    handle = iio_open("of://localhost:9999", target, 0); 
+    if (handle == NULL)
+    {
+        printf("Device open failed\n");
+        exit(1);
+    }
+
+    buf = (char *) malloc(iosize); 
+    buf = memset(buf, 0, iosize);
+    printf("Starting IO test\n");
+    start_timer(&start);
+    start_timer(&estart);
+    for(i=0;i<iops;i++)
+    {
+        data.iov_len = iosize;
+        data.iov_base = buf;
+        ret = iio_writev(handle, ctx, &data, 1, iosize, iosize, IIO_FLAG_ASYNC);
+        if (ret != 0)
+        {
+            printf("Error in IO request\n");
+        }
+    }
+    l = stop_timer(&estart);
+    while(1)
+    {
+        sleep(1000);
+    }
+
+    ret = iio_close(handle);
+
+    return 0;
+}
+

--- a/src/test/server.c
+++ b/src/test/server.c
@@ -23,14 +23,6 @@ char *hostname = "127.0.0.1";
 char *vdisk_dir = "/tmp";
 FILE *backing_file = NULL;
 
-/*
- * Dummy implementation of authorization for IO request
- */
-static int authorize(char *instance, char *device)
-{
-    return 1;
-}
-
 static int vdisk_read(struct qnio_msg *msg, struct iovec *returnd)
 {
     size_t n;
@@ -133,17 +125,6 @@ void *pdispatch(void *data)
 
     if (verbose) {
         printf("In server callback for msg #%ld\n", msg->hinfo.cookie);
-    }
-
-    if (!authorize(msg->hinfo.target, msg->hinfo.instance))
-    {
-        msg->hinfo.err = QNIO_ERR_AUTHZ_FAILED; 
-        msg->recv = NULL;
-        msg->hinfo.payload_size = 0;
-        msg->hinfo.flags = QNIO_FLAG_RESP;
-        msg->hinfo.io_flags = QNIO_FLAG_RESP;
-        qns_send_resp(msg);
-        return(NULL);
     }
 
     switch (opcode) {


### PR DESCRIPTION
Client will use key/cert under /var/lib/libqnio as <instanceid>.key and
<instanceid.cert>
Server will use key/cert under same directory as server.key and server.cert
Server may choose to validate client cert.
Certificates will be provisioned by an orchestration layer before VM
is provisioned
libqnio will expect the certificates to be available before it is initialized
otherwise will default to unsecure mode.

Client will pass instance id (VM id) for authorization on server.