### PR TITLE
Fix segfault in iio_open()

### DIFF
--- a/src/lib/qnio/iioapi.c
+++ b/src/lib/qnio/iioapi.c
@@ -481,7 +481,7 @@ iio_open(const char *uri, const char *devid, uint32_t flags)
     if (hostinfo == NULL) {
         nioDbg("Unable to read the host information for device %s\n", devid);
         hostinfo = (struct iio_vdisk_hostinfo *)malloc(sizeof (struct iio_vdisk_hostinfo));
-        strncpy(hostinfo->hosts[hostinfo->nhosts], uri, NAME_SZ);
+        strncpy(hostinfo->hosts[0], uri, NAME_SZ);
         hostinfo->nhosts = 1;
         hostinfo->failover_idx = 0;
     }


### PR DESCRIPTION
Fix for the following stacktrace:

(gdb) bt
0  0x00007f526163cdee in __strncpy_ssse3 () from /lib64/libc.so.6
1  0x00007f52643c4ba9 in iio_open (uri=0x7f5266432300 "of://127.0.0.1:9999", devid=0x7f5266431a80 "/t.raw", flags=0) at lib/qnio/iioapi.c:487
2  0x00007f5264d17f3e in vxhs_open (bs=<value optimized out>, options=<value optimized out>, bdrv_flags=<value optimized out>, errp=0x7fffbcd44308) at block/vxhs.c:308
3  0x00007f5264cbc328 in bdrv_open_common (filename=<value optimized out>, reference=<value optimized out>, options=0x7f5266454de0, flags=57346, parent=<value optimized out>,
    child_role=<value optimized out>, errp=0x7fffbcd44468) at block.c:1104
4  bdrv_open_inherit (filename=<value optimized out>, reference=<value optimized out>, options=0x7f5266454de0, flags=57346, parent=<value optimized out>, child_role=<value optimized out>, errp=
    0x7fffbcd44468) at block.c:1833
5  0x00007f5264cbd4d9 in bdrv_open_child (filename=0x7fffbcd46141 "vxhs://127.0.0.1:9999/t.raw", options=0x7f526644e980, bdref_key=0x7f5264dc9ab0 "file", parent=0x7f526644a720, child_role=
    0x7f5264ffe5e0, allow_none=true, errp=0x7fffbcd44468) at block.c:1588
6  0x00007f5264cbbf0b in bdrv_open_inherit (filename=0x7fffbcd46141 "vxhs://127.0.0.1:9999/t.raw", reference=<value optimized out>, options=0x7f526644e980, flags=24578,
    parent=<value optimized out>, child_role=<value optimized out>, errp=0x7fffbcd44548) at block.c:1794
7  0x00007f5264cbcd83 in bdrv_open (filename=<value optimized out>, reference=<value optimized out>, options=<value optimized out>, flags=<value optimized out>, errp=<value optimized out>)
    at block.c:1924
8  0x00007f5264cff7fc in blk_new_open (filename=0x7fffbcd46141 "vxhs://127.0.0.1:9999/t.raw", reference=0x0, options=0x7f5266449700, flags=16386, errp=<value optimized out>)
    at block/block-backend.c:160
9  0x00007f5264cb3151 in openfile (name=0x7fffbcd46141 "vxhs://127.0.0.1:9999/t.raw", flags=<value optimized out>, writethrough=false, opts=0x7f5266449700) at qemu-io.c:67
10 0x00007f5264cb3a64 in main (argc=<value optimized out>, argv=0x7fffbcd449c8) at qemu-io.c:604