### PR TITLE
Fix possible buffer overflows from target dir and file being opened

### DIFF
--- a/src/test/server.c
+++ b/src/test/server.c
@@ -36,7 +36,12 @@ static int vdisk_read(struct qnio_msg *msg, struct iovec *returnd)
     size = msg->hinfo.io_size;
     safe_strncpy(vdisk_path_temp, msg->hinfo.target, DIR_NAME_SZ);
     bname = basename(vdisk_path_temp);
-    sprintf(vdisk_path, "%s/%s", vdisk_dir, bname);
+    if (strlen(bname) + strlen(vdisk_dir) > DIR_NAME_SZ - 1) {
+        fprintf(stderr, "Combined length of directory path and "
+                "filename exceeds %d.\n", DIR_NAME_SZ - 1);
+        exit(-1);
+    }
+    snprintf(vdisk_path, DIR_NAME_SZ, "%s/%s", vdisk_dir, bname);
     backing_file = fopen(vdisk_path, "r");
     if (!backing_file) {
         printf("Error opening file %s\n", vdisk_path);
@@ -78,7 +83,12 @@ static int vdisk_write(struct qnio_msg *msg)
 
     safe_strncpy(vdisk_path_temp, msg->hinfo.target, DIR_NAME_SZ);
     bname = basename(vdisk_path_temp);
-    sprintf(vdisk_path, "%s/%s", vdisk_dir, bname);
+    if (strlen(bname) + strlen(vdisk_dir) > DIR_NAME_SZ - 1) {
+        fprintf(stderr, "Combined length of directory path and "
+                "filename exceeds %d.\n", DIR_NAME_SZ - 1);
+        exit(-1);
+    }
+    snprintf(vdisk_path, DIR_NAME_SZ, "%s/%s", vdisk_dir, bname);
     backing_file = fopen(vdisk_path, "r+");
     if (!backing_file) {
         printf("Error opening file %s\n", vdisk_path);
@@ -130,7 +140,12 @@ void *pdispatch(void *data)
         ps = new_ps(0);
         safe_strncpy(vdisk_path_temp, msg->hinfo.target, DIR_NAME_SZ);
         bname = basename(vdisk_path_temp);
-        sprintf(vdisk_path, "%s/%s", vdisk_dir, bname);
+        if (strlen(bname) + strlen(vdisk_dir) > DIR_NAME_SZ - 1) {
+            fprintf(stderr, "Combined length of directory path and "
+                    "filename exceeds %d.\n", DIR_NAME_SZ - 1);
+            exit(-1);
+        }
+        snprintf(vdisk_path, DIR_NAME_SZ, "%s/%s", vdisk_dir, bname);
         fd = open(vdisk_path, O_RDONLY);
         if (fd >= 0) {
             if (fstat(fd, &stat)== 0) {


### PR DESCRIPTION
(1) Use snprintf to prevent exceeding the size of dest string.
(2) Add a check to error out if the combined length of destination
    directory, and the file being opened, exceed what can be stored.