### PR TITLE
Packaging changes to build libvxhs RPMs from the source tar.gz

### DIFF
--- a/libvxhs.spec
+++ b/libvxhs.spec
@@ -1,0 +1,35 @@
+Name:           libvxhs 
+Version:        1.0
+Release:        1%{?dist}
+Summary:        Network communication library used to route IO packets from qemu-kvm guests to a remote IO server 
+Group:          Development
+License:        GPLv2
+URL:            https://github.com/VeritasHyperScale/libqnio
+Source:         %{name}-%{version}.tar.gz
+BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+
+%description
+libvxhs is a network communication library used to route IO packets from qemu-kvm guests to a remote IO server
+
+%prep
+%setup
+
+%build
+make %{?_smp_mflags}
+
+%install
+[ "$RPM_BUILD_ROOT" != "/" ] && rm -rf $RPM_BUILD_ROOT
+make install DESTDIR=$RPM_BUILD_ROOT
+
+%clean
+[ "$RPM_BUILD_ROOT" != "/" ] && rm -rf $RPM_BUILD_ROOT
+
+
+%files
+/usr/include/qnio
+/usr/lib64/libvxhs.so
+/usr/local/bin/*
+
+%changelog
+* Tue Feb 21 2017 Ashish Mittal <Ashish.Mittal@veritas.com> - 1.0
+- First checkin of the packaging spec file

--- a/src/Makefile
+++ b/src/Makefile
@@ -4,6 +4,7 @@ MAKEFILE = Makefile
 SHELL = /bin/sh
 CC    = gcc
 
+DESTDIR      ?=
 CPPFLAGS     = -Iinclude
 CFLAGS       = -fPIC -fno-strict-aliasing -Wall -Werror -g -pthread
 DEPFLAGS     = -MMD -MP -MT $@ -MF $(@D)/$(*F).d
@@ -60,14 +61,16 @@ clean:
 	\rm -f $(TEST_CLIENT_OBJS)
 
 install: all
-	mkdir -p $(HEADERS) || exit
-	cp -f include/qnio_api.h $(HEADERS)/qnio_api.h
-	cp -f $(BASE_TARGET) $(LIBRARY)/$(BASE_TARGET)
-	cp -f $(TEST_TARGET) ${TEST_TARGET_DIR}/$(TEST_TARGET)
-	cp -f $(TEST_CLIENT_TARGET) ${TEST_TARGET_DIR}/$(TEST_CLIENT_TARGET)
+	mkdir -p $(DESTDIR)$(HEADERS) || exit
+	mkdir -p $(DESTDIR)$(LIBRARY) || exit
+	mkdir -p $(DESTDIR)$(TEST_TARGET_DIR) || exit
+	cp -f include/qnio_api.h $(DESTDIR)$(HEADERS)/qnio_api.h
+	cp -f $(BASE_TARGET) $(DESTDIR)$(LIBRARY)/$(BASE_TARGET)
+	cp -f $(TEST_TARGET) $(DESTDIR)${TEST_TARGET_DIR}/$(TEST_TARGET)
+	cp -f $(TEST_CLIENT_TARGET) $(DESTDIR)${TEST_TARGET_DIR}/$(TEST_CLIENT_TARGET)
 
 uninstall:
-	rm -f $(HEADERS)/qnio_api.h
-	rm -f $(LIBRARY)/$(BASE_TARGET)
-	rm -f ${TEST_TARGET_DIR}/$(TEST_TARGET)
-	rm -f ${TEST_TARGET_DIR}/$(TEST_CLIENT_TARGET)
+	rm -f $(DESTDIR)$(HEADERS)/qnio_api.h
+	rm -f $(DESTDIR)$(LIBRARY)/$(BASE_TARGET)
+	rm -f $(DESTDIR)${TEST_TARGET_DIR}/$(TEST_TARGET)
+	rm -f $(DESTDIR)${TEST_TARGET_DIR}/$(TEST_CLIENT_TARGET)


### PR DESCRIPTION
$ rpm -qil libvxhs
Name        : libvxhs
Version     : 1.0
Release     : 1.el7
Architecture: x86_64
Install Date: Tue 21 Feb 2017 05:43:40 PM PST
Group       : Development
Size        : 666811
License     : GPLv2
Signature   : (none)
Source RPM  : libvxhs-1.0-1.el7.src.rpm
Build Date  : Tue 21 Feb 2017 05:43:20 PM PST
Build Host  : rhel72ga-build-upstream
Relocations : (not relocatable)
URL         : https://github.com/VeritasHyperScale/libqnio
Summary     : Network communication library used to route IO packets
from qemu-kvm guests to a remote IO server
Description :
libvxhs is a network communication library used to route IO packets from
qemu-kvm guests to a remote IO server
/usr/include/qnio
/usr/include/qnio/qnio_api.h
/usr/lib64/libvxhs.so
/usr/local/bin/qnio_client
/usr/local/bin/qnio_server