### PR TITLE
Per channel ssl

### DIFF
--- a/src/include/iio.h
+++ b/src/include/iio.h
@@ -5,6 +5,8 @@
 #ifndef IIO_HEADER_DEFINED
 #define IIO_HEADER_DEFINED
 
+#include <openssl/ssl.h>
+
 /*
  * Error values returned by library.
  */
@@ -97,6 +99,10 @@ struct qnio_msg
  */
 struct channel {
     struct channel_driver *cd;
+    char *cacert;
+    char *client_key;
+    char *client_cert;
+    SSL_CTX *ssl_ctx;
 };
 
 enum channel_type {
@@ -107,7 +113,8 @@ enum channel_type {
 typedef void (*qnio_notify) (struct qnio_msg *msg);
 struct channel_driver {
     enum channel_type chdrv_type;
-    struct channel *(*chdrv_open)(void *channel_arg);
+    struct channel *(*chdrv_open)(void *channel_arg, const char *cacert,
+                                  const char *client_key, const char *client_cert);
     void (*chdrv_close)(struct channel *channel);
     void (*chdrv_msg_resend_cleanup)(struct qnio_msg *);
     int (*chdrv_msg_send)(struct channel *channel, struct qnio_msg *msg);

--- a/src/include/qnio.h
+++ b/src/include/qnio.h
@@ -48,7 +48,6 @@ struct qnio_common_ctx {
     enum qnio_mode mode;
     uint64_t in, out; /* IN/OUT traffic counters */
     qnio_notify notify;
-    SSL_CTX *ssl_ctx;
 };
 
 enum NSReadState { /* Network stream read state */

--- a/src/include/qnio.h
+++ b/src/include/qnio.h
@@ -28,7 +28,6 @@
 #define IO_POOL_BUF_SIZE            65536 
 #define BUF_ALIGN                   4096
 #define CRC_MODULO                  256
-#define SECURE_IMPL                 "/var/lib/libvxhs/secure"
 #define SERVER_KEY                  "/var/lib/libvxhs/server.key"
 #define SERVER_CERT                 "/var/lib/libvxhs/server.cert"
 #define CLIENT_KEYSTORE             "/var/lib/libvxhs/"

--- a/src/include/qnio_api.h
+++ b/src/include/qnio_api.h
@@ -100,7 +100,9 @@ int32_t iio_max_version(void);
  *        EBADF  - Unable to open communication channel.
  *        EBUSY  - The call cannot be completed right now
  */
-void *iio_open(const char *uri, const char *devid, uint32_t flags);
+void *iio_open(const char *uri, const char *devid, uint32_t flags,
+               const char *cacert, const char *client_key,
+               const char *client_cert);
 
 /*
  * Close the device.

--- a/src/include/qnio_api.h
+++ b/src/include/qnio_api.h
@@ -90,6 +90,9 @@ int32_t iio_max_version(void);
  *    uri - const string of the format of://<hostname|ip>:port
  *    devid - Device ID.
  *    flags - currently unused, this must be set to 0
+ *    cacert - CA certificates file in PEM format
+ *    client_key - Client private key file in PEM format
+ *    client_cert - Client certificate file in PEM format
  * RETURNS:
  *    opeque device handle on success, NULL on failure.
  * DESCRIPTION:

--- a/src/include/qnio_server.h
+++ b/src/include/qnio_server.h
@@ -5,6 +5,7 @@
 
 #define MAX_EPOLL_UNITS             16 
 #define QNIO_DEFAULT_PORT           "9999"
+#define SECURE_IMPL                 "/var/lib/libvxhs/secure"
 
 /*
  * An epoll unit to allow for scaling on server.
@@ -36,5 +37,6 @@ struct qnio_server_ctx {
 qnio_error_t qns_server_init(qnio_notify server_notify);
 qnio_error_t qns_server_start(char *node, char *port);
 qnio_error_t qns_send_resp(struct qnio_msg *msg);
+int is_secure();
 
 #endif /* QNIO_SERVER_HEADER_DEFINED */

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -19,6 +19,5 @@ int compare_int(const void *x, const void *y);
 SSL_CTX *init_server_ssl_ctx(void); 
 SSL_CTX *init_client_ssl_ctx(const char *cacert, const char *client_key,
                       const char *client_cert); 
-int is_secure(); 
 
 #endif /* UTILS_HEADER_DEFINED */

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -17,7 +17,8 @@ char *safe_strncpy(char *dest, const char *src, size_t n);
 int compare_key(const void *x, const void *y);
 int compare_int(const void *x, const void *y);
 SSL_CTX *init_server_ssl_ctx(void); 
-SSL_CTX *init_client_ssl_ctx(const char *instanceid); 
+SSL_CTX *init_client_ssl_ctx(const char *cacert, const char *client_key,
+                      const char *client_cert); 
 int is_secure(); 
 
 #endif /* UTILS_HEADER_DEFINED */

--- a/src/lib/qnio/nio_client.c
+++ b/src/lib/qnio/nio_client.c
@@ -584,7 +584,7 @@ qnc_channel_open(void *channel_arg, const char *cacert, const char *client_key,
          * the existing channel. Return error if they don't match.
          */
         channel = &netch->channel;
-        if (cacert || client_key || client_cert) {
+        if (channel->ssl_ctx && (cacert || client_key || client_cert)) {
             if (strcmp(channel->cacert, cacert) != 0 ||
                 strcmp(channel->client_key, client_key) ||
                 strcmp(channel->client_cert, client_cert))

--- a/src/lib/qnio/nio_client.c
+++ b/src/lib/qnio/nio_client.c
@@ -621,6 +621,7 @@ qnc_channel_open(void *channel_arg, const char *cacert, const char *client_key,
         {
             nioDbg("Secure mode can only be enabled when cacert, client_key,"
                    " and client_cert are all specified");
+            pthread_mutex_unlock(&qnc_ctx->chnl_lock);
             return NULL;
         }
     }

--- a/src/lib/qnio/nio_client.c
+++ b/src/lib/qnio/nio_client.c
@@ -612,6 +612,19 @@ qnc_channel_open(void *channel_arg, const char *cacert, const char *client_key,
         return &netch->channel;
     }
 
+    /*
+     * Secure SSL communication is enabled by passing these three values.
+     * All, or none, should be passed.
+     */
+    if ( cacert || client_key || client_cert) {
+        if ( !cacert || !client_key || !client_cert)
+        {
+            nioDbg("Secure mode can only be enabled when cacert, client_key,"
+                   " and client_cert are all specified");
+            return NULL;
+        }
+    }
+
     netch = (struct network_channel *)malloc(sizeof (struct network_channel));
     memset(netch, 0, sizeof (struct network_channel));
     channel = &netch->channel;
@@ -620,7 +633,7 @@ qnc_channel_open(void *channel_arg, const char *cacert, const char *client_key,
      * Initialize SSL context for the new channel based on the certs and keys
      * passed by the user.
      */
-    if (!is_secure()) {
+    if (cacert == NULL) {
         nioDbg("Client is running in unsecure mode");
         channel->cacert = NULL;
         channel->client_key = NULL;

--- a/src/lib/qnio/nio_server.c
+++ b/src/lib/qnio/nio_server.c
@@ -17,6 +17,17 @@ static struct qnio_server_ctx *qns_ctx;
 static struct qnio_common_ctx *cmn_ctx;
 SSL_CTX *ssl_ctx;
 
+int
+is_secure()
+{
+    if (access(SECURE_IMPL, F_OK) != 0)
+    {
+        nioDbg("Server not running in secure mode\n");
+        return 0;
+    }
+    return 1;
+}
+
 static void
 disconnect(struct conn *c)
 {

--- a/src/lib/qnio/utils.c
+++ b/src/lib/qnio/utils.c
@@ -118,12 +118,20 @@ init_client_ssl_ctx(const char *cacert, const char *clientkey,
         return NULL;
     }
 
-    if (SSL_CTX_use_PrivateKey_file(ctx, clientkey, SSL_FILETYPE_PEM) < 0 ) 
+    if (SSL_CTX_use_PrivateKey_file(ctx, clientkey, SSL_FILETYPE_PEM) < 0) 
     {
-        nioDbg("Unable to use server key file");
+        nioDbg("Unable to use client key file");
         SSL_CTX_free(ctx);
         return NULL;
     }
+
+    if (SSL_CTX_load_verify_locations(ctx, cacert, NULL) < 0)
+    {
+        nioDbg("Unable to use client cacert file");
+        SSL_CTX_free(ctx);
+        return NULL;
+    }
+
     return ctx;
 }
 

--- a/src/lib/qnio/utils.c
+++ b/src/lib/qnio/utils.c
@@ -11,17 +11,6 @@
 #include "defs.h"
 #include "qnio.h"
 
-int 
-is_secure()
-{
-    if (access(SECURE_IMPL, F_OK) != 0)
-    {
-        nioDbg("Secure implementation not enabled\n");
-        return 0;
-    }
-    return 1;
-}
-
 SSL_CTX *
 init_server_ssl_ctx()
 {

--- a/src/lib/qnio/utils.c
+++ b/src/lib/qnio/utils.c
@@ -87,6 +87,12 @@ init_client_ssl_ctx(const char *cacert, const char *clientkey,
         return NULL;
     }
 
+    if (access(cacert, F_OK) != 0)
+    {
+        nioDbg("cacert not found %s", cacert);
+        return NULL;
+    }
+
     if (access(clientkey, F_OK) != 0)
     {
         nioDbg("Client key not found %s", clientkey);

--- a/src/lib/qnio/utils.c
+++ b/src/lib/qnio/utils.c
@@ -28,7 +28,9 @@ init_server_ssl_ctx()
     const SSL_METHOD *method;
     SSL_CTX *ctx = NULL;
 
-    nioDbg("initializing server ssl ctx %s\n", SERVER_KEY);
+    nioDbg("initializing server ssl ctx with key %s, cert %s\n",
+           SERVER_KEY, SERVER_CERT);
+
     if (access(SERVER_KEY, F_OK) != 0)
     {
         nioDbg("Server key not found");
@@ -69,27 +71,27 @@ init_server_ssl_ctx()
     return ctx;
 }
 
+/*
+ * None of the arguments can be NULL
+ */
 SSL_CTX *
-init_client_ssl_ctx(const char *instanceid)
+init_client_ssl_ctx(const char *cacert, const char *clientkey,
+             const char *clientcert)
 {
     const SSL_METHOD *method;
-    char clientkey[512] = { 0 };
-    char clientcert[512] = { 0 };
     SSL_CTX *ctx = NULL;
 
-    strcpy(clientkey, CLIENT_KEYSTORE);
-    strncat(clientkey, instanceid, 64);
-    strncat(clientkey, ".key", 4);
+    if ( !cacert || !clientkey || !clientcert)
+    {
+        nioDbg("cacert, client_key, and client_cert cannot be NULL");
+        return NULL;
+    }
 
     if (access(clientkey, F_OK) != 0)
     {
         nioDbg("Client key not found %s", clientkey);
         return NULL;
     }
-
-    strcpy(clientcert, CLIENT_KEYSTORE);
-    strncat(clientcert, instanceid, 64);
-    strncat(clientcert, ".cert", 5);
 
     if (access(clientcert, F_OK) != 0)
     {

--- a/src/lib/qnio/utils.c
+++ b/src/lib/qnio/utils.c
@@ -70,12 +70,6 @@ init_client_ssl_ctx(const char *cacert, const char *clientkey,
     const SSL_METHOD *method;
     SSL_CTX *ctx = NULL;
 
-    if ( !cacert || !clientkey || !clientcert)
-    {
-        nioDbg("cacert, client_key, and client_cert cannot be NULL");
-        return NULL;
-    }
-
     if (access(cacert, F_OK) != 0)
     {
         nioDbg("cacert not found %s", cacert);

--- a/src/test/client.c
+++ b/src/test/client.c
@@ -19,6 +19,14 @@
 
 #define BILLION                     1E9
 
+/*
+ * Please ensure the following per-device certs are installed
+ * for secure SSL testing
+ */
+#define CLIENT_KEY                  "/var/lib/libvxhs/testdevice.key"
+#define CLIENT_CERT                 "/var/lib/libvxhs/testdevice.pem"
+#define CACERT                      "/var/lib/libvxhs/cacert.pem"
+
 /* global variables */
 int iops = 10;
 int iosize = 8192;
@@ -124,7 +132,8 @@ int main(int argc, char **argv)
         exit(1);
     }
 
-    handle = iio_open("of://localhost:9999", target, 0); 
+    handle = iio_open("of://localhost:9999", target, 0, CACERT,
+                      CLIENT_KEY, CLIENT_CERT); 
     if (handle == NULL)
     {
         printf("Device open failed\n");


### PR DESCRIPTION
Changelog:
(1) Changed code to not use instance UUID for setting up SSL context.
(2) User is supposed to pass the cacert, client_key and client_cert
    files to iio_open(). These will be used to set up a per-channel secure SSL
    connection to the server. All three values are needed to set up a
    secure connection.
(3) If the secure channel to a particular host is already open, other
    block device connections to the same host will have to provide
    TLS/SSL credentials that match the original one.
(4) Set default locations for trusted client CA certificates
     based on user specified cacert file.

Steps to test SSL communication (using the supplied test client/server programs) is present in the commit log.