### PR TITLE
Drop specific references to QEMU

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
-# libqnio
-libqnio is a network communication library used to route IO packets from qemu-kvm guests to a remote IO server
+# libvxhs
+## The Veritas HyperScale storage connector library
+libvxhs is a storage connector library for accessing vdisks on Veritas
+HyperScale storage.

--- a/libvxhs.spec
+++ b/libvxhs.spec
@@ -1,7 +1,7 @@
 Name:           libvxhs 
 Version:        1.0
 Release:        1%{?dist}
-Summary:        Network communication library used to route IO packets from qemu-kvm guests to a remote IO server 
+Summary:        The Veritas HyperScale storage connector library
 Group:          Development
 License:        GPLv2
 URL:            https://github.com/VeritasHyperScale/libqnio
@@ -9,7 +9,8 @@ Source:         %{name}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 %description
-libvxhs is a network communication library used to route IO packets from qemu-kvm guests to a remote IO server
+libvxhs is a storage connector library for accessing vdisks on Veritas
+HyperScale storage.
 
 %prep
 %setup


### PR DESCRIPTION
The RPM spec file and README.md do not reflect the scope of the library accurately.  Any application can access vdisks using libvxhs and there is nothing QEMU-specific.

These commits drop references to QEMU and emphasize the general-purpose scope of the library.